### PR TITLE
Issue of boolean variable stopping the compilation of code

### DIFF
--- a/NetPrints/Translator/TranslatorUtil.cs
+++ b/NetPrints/Translator/TranslatorUtil.cs
@@ -99,6 +99,10 @@ namespace NetPrints.Translator
             {
                 return $"{obj}M";
             }
+            else if (type==TypeSpecifier.FromType<bool>())
+            {
+                return obj.ToString().ToLower();  //Bool false is converted to False, causing the issue in compilation
+            }
             else
             {
                 return obj.ToString();


### PR DESCRIPTION
Some times if you are using the node where input argument is the boolean variable translator translate the false to False value, which leads the compilation error "False" doesn't exist in the current context.

To fix this just make it ToLower and then work as expected.